### PR TITLE
Update API.php

### DIFF
--- a/Application/Core/API.php
+++ b/Application/Core/API.php
@@ -215,7 +215,7 @@ final class AAM_Core_API {
     public static function capabilityExists($cap) {
         $caps = self::getAllCapabilities();
         
-        return (is_scalar($cap) && array_key_exists($cap, $caps) ? true : false);
+        return ( (is_string($cap) || is_int($cap)) && array_key_exists($cap, $caps) ? true : false);
     }
     
     /**


### PR DESCRIPTION
is_scalar also returns true for booleans and floats, which are invalid array keys.