### PR TITLE
Add type checks to the capabilityExists and getAllCapabilities methods

### DIFF
--- a/Application/Core/API.php
+++ b/Application/Core/API.php
@@ -220,7 +220,7 @@ final class AAM_Core_API {
     public static function capabilityExists($cap) {
         $caps = self::getAllCapabilities();
         
-        return (!empty($caps) && !empty($caps) && is_string($cap) && is_array($caps) && array_key_exists($cap, $caps) ? true : false);
+        return !empty($cap) && !empty($caps) && is_string($cap) && is_array($caps) && array_key_exists($cap, $caps);
     }
     
     /**

--- a/Application/Core/API.php
+++ b/Application/Core/API.php
@@ -191,10 +191,15 @@ final class AAM_Core_API {
      * @access public
      */
     public static function getAllCapabilities() {
-        $caps = array();
-        
-        foreach (self::getRoles()->role_objects as $role) {
-            if (is_array($role->capabilities)) {
+        $caps  = array();
+        $roles = self::getRoles();
+
+	if (empty($roles->role_objects) || !is_array($roles->role_objects)){
+		return $caps;
+	}
+
+        foreach ($roles->role_objects as $role) {
+            if (!empty($role->capabilities) && is_array($role->capabilities) ) {
                 $caps = array_merge($caps, $role->capabilities);
             }
         }
@@ -215,7 +220,7 @@ final class AAM_Core_API {
     public static function capabilityExists($cap) {
         $caps = self::getAllCapabilities();
         
-        return (is_string($cap) && array_key_exists($cap, $caps) ? true : false);
+        return (!empty($caps) && !empty($caps) && is_string($cap) && is_array($caps) && array_key_exists($cap, $caps) ? true : false);
     }
     
     /**


### PR DESCRIPTION
During the fixing of a conflict with MonsterInsights and AAM I noticed some edge cases that are fixed in this pull request regarding type handling during capabilities checks