### PR TITLE
Issuing refreshable JWT tokens

### DIFF
--- a/Application/Service/Jwt.php
+++ b/Application/Service/Jwt.php
@@ -115,6 +115,10 @@ class AAM_Service_Jwt
                 'description' => __('Issue JWT Token', AAM_KEY),
                 'type'        => 'boolean',
             );
+            $args['refreshableJWT'] = array(
+                'description' => __('Issue a refreshable JWT Token', AAM_KEY),
+                'type'        => 'boolean',
+            );
 
             return $args;
         });
@@ -382,7 +386,9 @@ class AAM_Service_Jwt
     public function prepareLoginResponse(array $response, WP_REST_Request $request)
     {
         if ($request->get_param('issueJWT') === true) {
-            $jwt = $this->issueToken($response['user']->ID);
+            $refreshable = $request->get_param('refreshableJWT') ??
+                AAM_Core_Config::get('authentication.jwt.refreshable', false);
+            $jwt = $this->issueToken($response['user']->ID, null, null, $refreshable);
 
             $response['jwt'] = array(
                 'token'         => $jwt->token,

--- a/Application/Service/Jwt.php
+++ b/Application/Service/Jwt.php
@@ -386,7 +386,7 @@ class AAM_Service_Jwt
     public function prepareLoginResponse(array $response, WP_REST_Request $request)
     {
         if ($request->get_param('issueJWT') === true) {
-            $refreshable = $request->get_param('refreshableJWT') ??
+            $refreshable = $request->get_param('refreshableJWT') ?:
                 AAM_Core_Config::get('authentication.jwt.refreshable', false);
             $jwt = $this->issueToken($response['user']->ID, null, null, $refreshable);
 


### PR DESCRIPTION
This PR provides a simple way for issuing refreshable JWTs via `/aam/v2/authenticate` API endpoint. One can set `refreshableJWT` parameter to `true` when authenticating or use `authentication.jwt.refreshable` ConfigPress setting to modify the default token refreshability.