### PR TITLE
Enable to sent and receive JWT as cookie

### DIFF
--- a/Application/Service/Jwt.php
+++ b/Application/Service/Jwt.php
@@ -367,7 +367,7 @@ class AAM_Service_Jwt
         $claims = AAM_Core_Jwt_Issuer::getInstance()->validateToken($jwt->jwt);
 
         if ($claims->isValid === true) {
-            if ($this->revokeUserToken($claims->userId, $jwt)) {
+            if ($this->revokeUserToken($claims->userId, $jwt->jwt)) {
                 $response = new WP_REST_Response(
                     array('message' => 'Token revoked successfully'), 200
                 );


### PR DESCRIPTION
Purpose of the changes are to make it possible to sent and receive the jwt in a cookie if the respective ConfigPress parameter is set. 
This is especially helpful to secure api calls from JS Frontends (React, Angular, Vue) so the cookie do not have to be stored in local or session storage.

1. $jwt = $this->extractToken(); enables to extract the JWT from the cookie
2. function setJWTCookie enables to sent the JWT as a cookie additionally if the respective ConfigPress parameter is set
   - You might change line 784 if this should become a regular ConfigPress parameter. I didn't know how to achieve that.
   - Some using the setcookie() function didn't work. The cookie was simply not set. Don't know if this was due to the PHP version running on the server or whatever. But with the header() it does work. Just in case you are wondering :-)

If you integrate this to the master branch, let me know if I should provide a description for the config press parameter. As to make it work from a js FrontEnd with a different domain there might have to be set some headers to allow cross-origin calls. I use the Plugin HTTP Headers (https://de.wordpress.org/plugins/http-headers/) for that.

PS: I have seen that you have removed a auth cookie in the past due to a security issue through auto login / automatic re-login. This way the cookie will only be set if the admin desired it that way, as in my case using WP as headless CMS.

Let me know what you think.