### PR TITLE
Fix creating user roles

### DIFF
--- a/application/Core/Restful/Role.php
+++ b/application/Core/Restful/Role.php
@@ -99,8 +99,8 @@ class AAM_Core_Restful_Role
                     'slug' => array(
                         'description' => __('Unique role slug', AAM_KEY),
                         'type'        => 'string',
-                        'validate_callback' => function($value) {
-                            return $this->_validate_role_slug_uniqueness($value);
+                        'validate_callback' => function($value, $request) {
+                            return $this->_validate_role_slug_uniqueness($value, $request);
                         }
                     ),
                     'name' => array(


### PR DESCRIPTION
Attemting to create a new user role with AAM results in the following backtrace. This fixes it.

```
[22-Feb-2023 14:24:52 UTC] PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function AAM_Core_Restful_Role::_validate_role_slug_uniqueness(), 1 passed in /var/www/html/wp-content/plugins/advanced-access-manager/application/Core/Restful/Role.php on line 103 and exactly 2 expected in /var/www/html/wp-content/plugins/advanced-access-manager/application/Core/Restful/Role.php:662
Stack trace:
#0 /var/www/html/wp-content/plugins/advanced-access-manager/application/Core/Restful/Role.php(103): AAM_Core_Restful_Role->_validate_role_slug_uniqueness('test')
#1 /var/www/html/wp-includes/rest-api/class-wp-rest-request.php(911): AAM_Core_Restful_Role->{closure}('test', Object(WP_REST_Request), 'slug')
#2 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(1007): WP_REST_Request->has_valid_params()
#3 /var/www/html/wp-includes/rest-api/class-wp-rest-server.php(442): WP_REST_Server->dispatch(Object(WP_REST_Request))
#4 /var/www/html/wp-includes/rest-api.php(410): WP_REST_Server->serve_request('/aam/v2/role')
#5 /var/www/html/wp-includes/class-wp-hook.php(308): rest_api_loaded(Object(WP))
#6 /var/www/html/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters('', Array)
#7 /var/www/html/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#8 /var/www/html/wp-includes/class-wp.php(399): do_action_ref_array('parse_request', Array)
#9 /var/www/html/wp-includes/class-wp.php(780): WP->parse_request('')
#10 /var/www/html/wp-includes/functions.php(1332): WP->main('')
#11 /var/www/html/wp-blog-header.php(16): wp()
#12 /var/www/html/index.php(17): require('/var/www/html/w...')
#13 {main}
  thrown in /var/www/html/wp-content/plugins/advanced-access-manager/application/Core/Restful/Role.php on line 662
```