### PR TITLE
Preserve the canonical admin URL in the default login redirect

### DIFF
--- a/application/Service/LoginRedirect.php
+++ b/application/Service/LoginRedirect.php
@@ -151,11 +151,12 @@ class AAM_Service_LoginRedirect
     {
         $redirect = AAM::api()->user($user->ID)->login_redirect()->get_redirect();
 
+        // The default target is WordPress's own admin URL, which is already
+        // canonical and safe. Return it verbatim: routing it through the
+        // redirect pipeline normalises it via Misc::parse_url, whose output is
+        // a comparison key with the scheme, host and trailing slash stripped.
         if ($redirect['type'] === 'default') {
-            $redirect = [
-                'type'         => 'url_redirect',
-                'redirect_url' => admin_url()
-            ];
+            return admin_url();
         }
 
         return AAM::api()->redirect->to_redirect_url($redirect);


### PR DESCRIPTION
Fixes #506.

## The problem

When the login redirect type is `default`, `get_user_redirect_url()` re-wraps `admin_url()` as a `url_redirect` and pushes it through the redirect pipeline. That routes it into `Misc::sanitize_url()`, which returns the normalised `relative` form (scheme and host dropped), and `Misc::parse_url()`, which strips the trailing slash.

So `https://example.com/wp-admin/` comes back out as `/wp-admin`.

The normalisation is not wrong in itself — `parse_url()` exists to build a comparison key, and lowercasing, sorting query params and trimming the slash are all reasonable for that. The problem is that the same value is then returned as an HTTP `Location`.

## Why it matters

Behind a reverse proxy, the missing trailing slash is load-bearing. nginx answers the slash-less path with its own canonical 301, built from the port it listens on rather than the public one:

```
GET /wp-admin  ->  301  Location: http://example.com:8080/wp-admin/
```

That port is internal to the cluster, so the browser times out. Administrators can sign in but never arrive at the admin area — while `/wp-admin/` opened directly works fine, which makes the fault look account-specific. Since a 301 is cached permanently, it also survives clearing cookies, clearing the cache and switching browsers.

## The change

Return `admin_url()` verbatim for the `default` type. It is already canonical and already safe, so there is nothing for the normaliser to add.

## Verification

Measured with our own `login_redirect` filter removed, so AAM is the only thing under test:

| | `login_redirect` returns |
|---|---|
| `master` as-is | `/wp-admin` |
| with this patch | `https://example.com/wp-admin/` |

Environment: WordPress 7.0.4, PHP 8.4, Bedrock layout, nginx `listen 8080` behind a TLS-terminating ingress.

## Scope

Deliberately narrow — it only touches the `default` branch, so configured redirects keep going through the existing pipeline unchanged.

A custom **Redirect to a URL** value entered as `https://example.com/wp-admin/` is still stored and returned as `/wp-admin`, so custom targets lose the trailing slash too. Fixing that properly means separating "normalise for comparison" from "sanitise for redirect" inside `Misc`, which is a wider change and riskier — `parse_url()` output is also used for URI access rule matching. Glad to extend this PR in that direction if you would rather have both handled together. Issue #506 also notes two smaller things spotted in `Misc::parse_url()` while reading it.
